### PR TITLE
Initial testing setup for the plugin mutation

### DIFF
--- a/config/setupAfterEnv.js
+++ b/config/setupAfterEnv.js
@@ -1,0 +1,3 @@
+import { toMatchFile } from 'jest-file-snapshot';
+
+expect.extend({ toMatchFile });

--- a/jest.config.js
+++ b/jest.config.js
@@ -126,7 +126,7 @@ module.exports = {
   // setupFiles: [],
 
   // A list of paths to modules that run some code to configure or set up the testing framework before each test
-  // setupFilesAfterEnv: [],
+  setupFilesAfterEnv: ['./config/setupAfterEnv.js'],
 
   // A list of paths to snapshot serializer modules Jest should use for snapshot testing
   // snapshotSerializers: [],
@@ -147,9 +147,10 @@ module.exports = {
   // ],
 
   // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
-  // testPathIgnorePatterns: [
-  //   "\\\\node_modules\\\\"
-  // ],
+  testPathIgnorePatterns: [
+    "\\\\node_modules\\\\",
+    "\\\\__fixtures__\\\\"
+  ],
 
   // The regexp pattern or array of patterns that Jest uses to detect test files
   // testRegex: [],
@@ -181,7 +182,9 @@ module.exports = {
   // verbose: undefined,
 
   // An array of regexp patterns that are matched against all source file paths before re-running tests in watch mode
-  // watchPathIgnorePatterns: [],
+  "watchPathIgnorePatterns": [
+    "__fixtures__\\/[^/]+\\/(output|error)\\.js"
+  ]
 
   // Whether to use watchman for file crawling
   // watchman: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -2012,6 +2012,29 @@
 				"babel-preset-current-node-syntax": "^0.1.2"
 			}
 		},
+		"babel-test": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/babel-test/-/babel-test-0.2.3.tgz",
+			"integrity": "sha512-1eh7ZU1Hi7IQKHveu9ATiDZZJuEt4qnszTzF4TcALDT4CyFCAwfPzGGvEUBtFJI1hrAqiYNOx6RHwvpjcGV6jQ==",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.4.1",
+				"error-stack-parser": "^2.0.2",
+				"escape-string-regexp": "^1.0.5",
+				"strip-ansi": "^5.0.0"
+			},
+			"dependencies": {
+				"strip-ansi": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^4.1.0"
+					}
+				}
+			}
+		},
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -2659,6 +2682,15 @@
 				"is-arrayish": "^0.2.1"
 			}
 		},
+		"error-stack-parser": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.6.tgz",
+			"integrity": "sha512-d51brTeqC+BHlwF0BhPtcYgF5nlzf9ZZ0ZIUQNZpc9ZB9qw5IJ2diTrBY9jlCJkTLITYPjmiX6OWCwH+fuyNgQ==",
+			"dev": true,
+			"requires": {
+				"stackframe": "^1.1.1"
+			}
+		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -3220,6 +3252,23 @@
 			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
 			"dev": true,
 			"optional": true
+		},
+		"filename-reserved-regex": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
+			"integrity": "sha1-q/c9+rc10EVECr/qLZHzieu/oik=",
+			"dev": true
+		},
+		"filenamify": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/filenamify/-/filenamify-4.1.0.tgz",
+			"integrity": "sha512-KQV/uJDI9VQgN7sHH1Zbk6+42cD6mnQ2HONzkXUfPJ+K2FC8GZ1dpewbbHw0Sz8Tf5k3EVdHVayM4DoAwWlmtg==",
+			"dev": true,
+			"requires": {
+				"filename-reserved-regex": "^2.0.0",
+				"strip-outer": "^1.0.1",
+				"trim-repeated": "^1.0.0"
+			}
 		},
 		"fill-range": {
 			"version": "4.0.0",
@@ -5014,6 +5063,76 @@
 					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
 					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
 					"dev": true
+				}
+			}
+		},
+		"jest-file-snapshot": {
+			"version": "0.3.8",
+			"resolved": "https://registry.npmjs.org/jest-file-snapshot/-/jest-file-snapshot-0.3.8.tgz",
+			"integrity": "sha512-rcR2i3SdlbJQNOpakj1fCMjsBAl2F5NQJ2/lHwbvGngwbxW+c/crivMFuKmssxo2o1uVTeWlSGbcSu7uDQY1+w==",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.4.2",
+				"filenamify": "^4.1.0",
+				"jest-diff": "^24.8.0",
+				"mkdirp": "^0.5.1"
+			},
+			"dependencies": {
+				"@jest/types": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
+					"integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^1.1.1",
+						"@types/yargs": "^13.0.0"
+					}
+				},
+				"@types/yargs": {
+					"version": "13.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.8.tgz",
+					"integrity": "sha512-XAvHLwG7UQ+8M4caKIH0ZozIOYay5fQkAgyIXegXT9jPtdIGdhga+sUEdAr1CiG46aB+c64xQEYyEzlwWVTNzA==",
+					"dev": true,
+					"requires": {
+						"@types/yargs-parser": "*"
+					}
+				},
+				"diff-sequences": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.9.0.tgz",
+					"integrity": "sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==",
+					"dev": true
+				},
+				"jest-diff": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.9.0.tgz",
+					"integrity": "sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.1",
+						"diff-sequences": "^24.9.0",
+						"jest-get-type": "^24.9.0",
+						"pretty-format": "^24.9.0"
+					}
+				},
+				"jest-get-type": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.9.0.tgz",
+					"integrity": "sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q==",
+					"dev": true
+				},
+				"pretty-format": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
+					"integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^24.9.0",
+						"ansi-regex": "^4.0.0",
+						"ansi-styles": "^3.2.0",
+						"react-is": "^16.8.4"
+					}
 				}
 			}
 		},
@@ -7691,6 +7810,12 @@
 			"integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
 			"dev": true
 		},
+		"stackframe": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.1.1.tgz",
+			"integrity": "sha512-0PlYhdKh6AfFxRyK/v+6/k+/mMfyiEBbTM5L94D0ZytQnJ166wuwoTYLHFWGbs2dpA8Rgq763KGWmN1EQEYHRQ==",
+			"dev": true
+		},
 		"static-extend": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -7809,6 +7934,15 @@
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.0.tgz",
 			"integrity": "sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w==",
 			"dev": true
+		},
+		"strip-outer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
+			"integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
+			"dev": true,
+			"requires": {
+				"escape-string-regexp": "^1.0.2"
+			}
 		},
 		"supports-color": {
 			"version": "5.5.0",
@@ -8016,6 +8150,15 @@
 			"dev": true,
 			"requires": {
 				"punycode": "^2.1.0"
+			}
+		},
+		"trim-repeated": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
+			"integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
+			"dev": true,
+			"requires": {
+				"escape-string-regexp": "^1.0.2"
 			}
 		},
 		"tslib": {

--- a/package.json
+++ b/package.json
@@ -29,12 +29,14 @@
 		"@babel/parser": "^7.9.6",
 		"@babel/traverse": "^7.9.6",
 		"babel-plugin-tester": "^9.0.1",
-		"jest": "^25.5.4",
+		"babel-test": "^0.2.3",
 		"eslint": "^6.8.0",
+		"eslint-plugin-evelyn": "^2.0.0",
 		"eslint-plugin-mocha": "^5.3.0",
 		"eslint-plugin-node": "^9.2.0",
 		"eslint-plugin-unicorn": "^9.1.1",
-		"eslint-plugin-evelyn": "^2.0.0"
+		"jest": "^25.5.4",
+		"jest-file-snapshot": "^0.3.8"
 	},
 	"dependencies": {
 		"@babel/preset-env": "^7.4.5"

--- a/plugin/__tests__/__fixtures__/basic/code.js
+++ b/plugin/__tests__/__fixtures__/basic/code.js
@@ -1,0 +1,20 @@
+const global = {prop: "test"};
+
+$shouldNotMutate(['foo']);
+const foo = (foo) => {
+    foo.prop = "pie";
+};
+
+$shouldNotMutate(['foo']);
+function bar(foo) {
+    foo.prop = 'Test';
+}
+
+/**
+ * This does not currently work
+ */
+$shouldNotMutate(['foo']);
+const pizza = foo => console.log(foo);
+
+foo(global);
+bar(global);

--- a/plugin/__tests__/__fixtures__/basic/output.js
+++ b/plugin/__tests__/__fixtures__/basic/output.js
@@ -1,0 +1,152 @@
+const propPath = function (path, property) {
+  if (/^[a-zA-Z_$][\w$]*$/.test(property)) {
+    return `${path}.${property}`;
+  } else if (/^\d$/.test(property)) {
+    return `${path}[${property}]`;
+  } else {
+    return `${path}["${property}"]`;
+  }
+};
+
+const proxify = (target, options = {}) => {
+  // Early return for non-objects
+  if (!(target instanceof Object)) return target; // Options
+
+  const {
+    deep = false,
+    prototype = false
+  } = options; // Naming properties for mutation tracing in errors
+
+  let {
+    name = typeof target.name === "string" && target.name,
+    path = "target"
+  } = options;
+  if (name !== "undefined" && name !== false) path = propPath(path, name); // If the proxy trap was triggered by the function to test
+  // TODO: implement, possibly make optional?
+
+  const triggeredByFunction = true; // Proxy handler
+
+  const handler = {
+    // Accessor edge case traps
+    getOwnPropertyDescriptor(dummyTarget, prop) {
+      /*
+      	Early return for cached read-only properties, prevents the below invariant when adding read-only properties to the dummy:
+      	"The result of Object.getOwnPropertyDescriptor(target) can be applied to the target object using Object.defineProperty() and will not throw an exception."
+      */
+      const dummyDescriptor = Reflect.getOwnPropertyDescriptor(...arguments);
+      if (dummyDescriptor) return dummyDescriptor; // Reflect using the real target, not the dummy
+
+      const reflectArguments = [...arguments];
+      reflectArguments[0] = target;
+      const descriptor = Reflect.getOwnPropertyDescriptor(...reflectArguments); // Early return for non-existing properties
+
+      if (!descriptor) return; // If has a value instead of accessors
+
+      const isValueDesc = ("value" in descriptor);
+
+      if (deep) {
+        if (isValueDesc) {
+          descriptor.value = proxify(descriptor.value, { ...options,
+            path,
+            name: prop
+          });
+        } else {// descriptor.set = proxify(descriptor.set, {...options, path, name: prop}); // TODO: apply traps
+          // descriptor.get = proxify(descriptor.get, {...options, path, name: prop}); // TODO: apply traps
+        }
+      } else if (!isValueDesc) {} // descriptor.set = descriptor.set && new Proxy(descriptor.set, descriptorSetHandler); // TODO: apply traps
+
+      /*
+      	Add read-only props to `dummyTarget` to meet the below invariant:
+      	"A property cannot be reported as existent, if it does not exists as an own property of the target object and the target object is not extensible."
+      */
+
+
+      const isReadOnly = descriptor.writable === false || descriptor.configurable === false;
+      if (isReadOnly) Object.defineProperty(dummyTarget, prop, descriptor);
+      return descriptor;
+    }
+
+  }; // Reflect to the real target for unused traps
+  // This is to avoid the navtive fallback to the `dummyTarget`
+
+  const addNoopReflectUsingRealTargetTrap = trap => {
+    handler[trap] = function () {
+      // Reflect using the real target, not the dummy
+      const reflectArguments = [...arguments];
+      reflectArguments[0] = target;
+      return Reflect[trap](...reflectArguments);
+    };
+  };
+
+  addNoopReflectUsingRealTargetTrap("isExtensible");
+  addNoopReflectUsingRealTargetTrap("has");
+  addNoopReflectUsingRealTargetTrap("ownKeys");
+  addNoopReflectUsingRealTargetTrap("apply");
+  addNoopReflectUsingRealTargetTrap("construct"); // Getting traps for deep mutation assertions
+
+  const addDeepGetTrap = trap => {
+    handler[trap] = function (dummyTarget, prop) {
+      // Reflect using the real target, not the dummy
+      const reflectArguments = [...arguments];
+      reflectArguments[0] = target;
+      if (trap === "getPrototypeOf") prop = "__proto__";
+      const real = Reflect[trap](...reflectArguments);
+      return proxify(real, { ...options,
+        path,
+        name: prop
+      });
+    };
+  };
+
+  deep && addDeepGetTrap("get"); // Covered by getOwnPropertyDescriptor, but is more specific
+
+  prototype && addDeepGetTrap("getPrototypeOf"); // Mutation traps for erroring
+
+  const addSetTrap = trap => {
+    handler[trap] = function (dummyTarget, prop) {
+      // Reflect using the real target, not the dummy
+      const reflectArguments = [...arguments];
+      reflectArguments[0] = target; // Naming properties for mutation tracing in errors
+
+      if (trap !== "preventExtensions") {
+        if (trap === "setPrototypeOf") prop = "__proto__";
+        path += `.${prop}`;
+      }
+
+      if (triggeredByFunction) throw new Error(`Mutation assertion failed. \`${trap}\` trap triggered on \`${path}\`.`);
+      return Reflect[trap](...reflectArguments);
+    };
+  };
+
+  addSetTrap("set"); // Covered by defineProperty, but is more specific
+
+  addSetTrap("defineProperty");
+  addSetTrap("deleteProperty");
+  prototype && addSetTrap("setPrototypeOf");
+  addSetTrap("preventExtensions"); // Don't use the true `target` as the proxy target to avoid issues with read-only types
+  // Create `dummyTarget` based on the `target`'s constructor
+
+  const dummyTarget = new (Object.getPrototypeOf(target).constructor)();
+  return new Proxy(dummyTarget, handler);
+};
+
+const global = {
+  prop: "test"
+};
+
+const foo = foo => {
+  foo.prop = "pie";
+};
+
+function bar(foo) {
+  foo.prop = 'Test';
+}
+/**
+ * This does not currently work
+ */
+
+
+const pizza = foo => console.log(foo);
+
+foo(global);
+bar(global);

--- a/plugin/__tests__/__fixtures__/noop/code.js
+++ b/plugin/__tests__/__fixtures__/noop/code.js
@@ -1,0 +1,14 @@
+const global = {prop: "test"};
+
+const foo = (foo) => {
+    foo.prop = "pie";
+};
+
+function bar(foo) {
+    foo.prop = 'Test';
+}
+
+const pizza = foo => console.log(foo);
+
+foo(global);
+bar(global);

--- a/plugin/__tests__/__fixtures__/noop/output.js
+++ b/plugin/__tests__/__fixtures__/noop/output.js
@@ -1,0 +1,16 @@
+const global = {
+  prop: "test"
+};
+
+const foo = foo => {
+  foo.prop = "pie";
+};
+
+function bar(foo) {
+  foo.prop = 'Test';
+}
+
+const pizza = foo => console.log(foo);
+
+foo(global);
+bar(global);

--- a/plugin/__tests__/plugin.js
+++ b/plugin/__tests__/plugin.js
@@ -1,0 +1,8 @@
+import path from 'path';
+import { create } from 'babel-test';
+
+const { fixtures } = create({
+    plugins: [require.resolve('..')],
+});
+
+fixtures('my plugin', path.join(__dirname, '__fixtures__'));


### PR DESCRIPTION
This setup enables us to quickly update file snapshots (by running `jest --watch` and following the interactive guide after the tests fail) and does in fact work. 

I've also additionally handled removing the """decorator""" during the build process. Now all that's left is the handling of the variables itself