### PR TITLE
New: Support arrow function concise body syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,20 +75,6 @@ module.exports = {
 };
 ```
 
-## Caveats
-
-Arrow functions with the concise body syntax do not currently work with Will Mutate.
-
-```js
-// Doesn't work
-$shouldNotMutate(["foo"]);
-const pizza = foo => JSON.parse("{}");
-
-// Works
-$shouldNotMutate(["foo"]);
-const pizza = foo => {return JSON.parse("{}");};
-```
-
 ## Alternatives
 
 - TypeScript or Flow typings

--- a/plugin/__tests__/__fixtures__/basic/code.js
+++ b/plugin/__tests__/__fixtures__/basic/code.js
@@ -12,9 +12,6 @@ function bar (foo, other) {
 	other.prop = "Don't change me";
 }
 
-/**
- * This does not currently work
- */
 $shouldNotMutate(["foo"]);
 const pizza = foo => JSON.parse("{}");
 

--- a/plugin/__tests__/__fixtures__/basic/output.js
+++ b/plugin/__tests__/__fixtures__/basic/output.js
@@ -201,12 +201,12 @@ function bar(foo, other) {
   _will_mutate_check_foo.prop = "Test";
   other.prop = "Don't change me";
 }
-/**
- * This does not currently work
- */
 
+const pizza = foo => {
+  const _will_mutate_check_foo = _will_mutate_check_proxify(foo);
 
-const pizza = foo => JSON.parse("{}");
+  return JSON.parse("{}");
+};
 
 foo(globalVariable);
 bar(globalVariable);


### PR DESCRIPTION
Function traversal now converts arrow function concise body syntax to standard arrow functions (with block and return statement).

Fixes: #14